### PR TITLE
Adds the ability to make multiple requests + changes backend URL + tests

### DIFF
--- a/LearningJourney/Modules/Core/CoreEnvironment/CoreEnvironment/Resources/Development.xcconfig
+++ b/LearningJourney/Modules/Core/CoreEnvironment/CoreEnvironment/Resources/Development.xcconfig
@@ -9,7 +9,8 @@
 // https://help.apple.com/xcode/#/dev745c5c974
 
 SLASH=/
-BASE_URL=http:$(SLASH)/192.168.0.115:9000/
+//BASE_URL=http:$(SLASH)/192.168.0.115:9000/
+BASE_URL=https:$(SLASH)/df99-2001-1284-f016-3bdd-1d9e-4de1-dc9f-a013.ngrok.io/
 ENV_NAME=DEV
 
 #include "../../../../../Pods/Target Support Files/Pods-CoreEnvironment/Pods-CoreEnvironment.debug.xcconfig"

--- a/LearningJourney/Modules/Core/CoreEnvironment/CoreEnvironment/Resources/Production.xcconfig
+++ b/LearningJourney/Modules/Core/CoreEnvironment/CoreEnvironment/Resources/Production.xcconfig
@@ -9,7 +9,12 @@
 // https://help.apple.com/xcode/#/dev745c5c974
 
 SLASH=/
-BASE_URL = https:$(SLASH)/learning-journey-backend-prod.herokuapp.com/
+//BASE_URL = https:$(SLASH)/learning-journey-backend-prod.herokuapp.com/
+BASE_URL = http:$(SLASH)/learningjourney.sa-east-1.elasticbeanstalk.com/
+//BASE_URL=https:$(SLASH)/df99-2001-1284-f016-3bdd-1d9e-4de1-dc9f-a013.ngrok.io/
+//BASE_URL=http:$(SLASH)/192.168.18.79:9000/
+//BASE_URL = https:$(SLASH)/learning-journey-qa.herokuapp.com/
+// TODO create a separate staging env
 ENV_NAME=PROD
 
 #include "../../../../../Pods/Target Support Files/Pods-CoreEnvironment/Pods-CoreEnvironment.debug.xcconfig"

--- a/LearningJourney/Modules/Core/CoreInjector/CoreInjector/Sources/DependencyContainer.swift
+++ b/LearningJourney/Modules/Core/CoreInjector/CoreInjector/Sources/DependencyContainer.swift
@@ -16,6 +16,7 @@ public final class DefaultDependencyContainer: DependencyContainer {
         keyOptions: .strongMemory,
         valueOptions: .weakMemory)
     
+    public init() {}
     
     // MARK: - Container methods
     

--- a/LearningJourney/Modules/Core/CoreNetworking/CoreNetworking/Sources/ApiRequest.swift
+++ b/LearningJourney/Modules/Core/CoreNetworking/CoreNetworking/Sources/ApiRequest.swift
@@ -15,7 +15,7 @@ public enum ApiError: Error {
     case notAllowed
 }
 
-public protocol ApiProtocol {
+public protocol ApiProtocol: AnyObject {
     typealias Completion = (Result<Data, ApiError>) -> Void
     init(endpoint: ApiEndpoint)
     func make(completion: @escaping Completion) -> ApiProtocol?

--- a/LearningJourney/Modules/Features/JAuthentication/JAuthentication/Sources/Data/AuthenticationRepository.swift
+++ b/LearningJourney/Modules/Features/JAuthentication/JAuthentication/Sources/Data/AuthenticationRepository.swift
@@ -1,8 +1,9 @@
 import Foundation
 import CoreAuthentication
+import CoreNetworking
 
 enum AuthenticationError: Error {
-    case api(Error)
+    case api(ApiError)
     case parsing(Error)
     case caching
     case notAuthenticated

--- a/LearningJourney/Modules/Features/JAuthentication/JAuthentication/Sources/Preview/LoginViewModelMock.swift
+++ b/LearningJourney/Modules/Features/JAuthentication/JAuthentication/Sources/Preview/LoginViewModelMock.swift
@@ -2,6 +2,8 @@
 import AuthenticationServices
 
 final class LoginViewModelMock: LoginViewModeling {
+    var isShowingSIWAAlert: Bool = false
+    
     func handleAuthStatusChange(_ output: NotificationCenter.Publisher.Output) {}
     
     func handleRequest(request: ASAuthorizationAppleIDRequestProtocol) {}

--- a/LearningJourney/Modules/Features/JAuthentication/JAuthentication/Sources/Scenes/Login/Domain/UseCases/SignInWithAppleUseCase.swift
+++ b/LearningJourney/Modules/Features/JAuthentication/JAuthentication/Sources/Scenes/Login/Domain/UseCases/SignInWithAppleUseCase.swift
@@ -9,7 +9,7 @@ protocol SignInWithAppleUseCaseProtocol {
 
 enum SignInWithAppleUseCaseError: Error {
     case systemError(Error)
-    case repository(Error)
+    case repository(AuthenticationError)
     case invalidCredentialType
 }
 
@@ -53,7 +53,7 @@ final class SignInWithAppleUseCase: SignInWithAppleUseCaseProtocol {
             email: credentials.email)
         repository.signInWithApple(using: payload) {
             completion($0
-                        .mapError { .repository($0 )}
+                        .mapError { .repository($0)}
                         .map { _ in })
         }
     }

--- a/LearningJourney/Modules/Features/JAuthentication/JAuthentication/Sources/Scenes/Login/Domain/UseCases/ValidateTokenUseCase.swift
+++ b/LearningJourney/Modules/Features/JAuthentication/JAuthentication/Sources/Scenes/Login/Domain/UseCases/ValidateTokenUseCase.swift
@@ -2,6 +2,7 @@ import CoreAuthentication
 
 enum ValidateTokenUseCaseError: Error {
     case invalidToken
+    case userNotCreated
 }
 
 protocol ValidateTokenUseCaseProtocol {

--- a/LearningJourney/Modules/Features/JAuthentication/JAuthentication/Sources/Scenes/Login/View/LoginView.swift
+++ b/LearningJourney/Modules/Features/JAuthentication/JAuthentication/Sources/Scenes/Login/View/LoginView.swift
@@ -27,6 +27,12 @@ struct LoginView<ViewModel>: View where ViewModel: LoginViewModeling {
                 contentView
             }
         }
+        .alert(isPresented: $viewModel.isShowingSIWAAlert) {
+            Alert(
+                title: Text("Please, remove this app from the apps that are using your Apple ID and try again"),
+                message: Text("To do so, please go to your iPhone's configuration -> Your account -> password and security -> Apps using Apple ID -> Learning Journey -> click on Stop using this Apple ID.\nAlso, please be sure that you're sending your name"),
+                dismissButton: .cancel(Text("OK")))
+        }
     }
     
     // fazer a tela aqui
@@ -57,7 +63,6 @@ struct LoginView<ViewModel>: View where ViewModel: LoginViewModeling {
                 .frame(height: 50)
                 .cornerRadius(10)
                 .signInWithAppleButtonStyle(colorScheme == .dark ? .white : .black )
-               
             }
             .padding(30)
         }

--- a/LearningJourney/Modules/Features/JLibrary/JLibrary/Sources/Data/LibraryRepository.swift
+++ b/LearningJourney/Modules/Features/JLibrary/JLibrary/Sources/Data/LibraryRepository.swift
@@ -9,7 +9,7 @@ protocol LibraryRepositoryProtocol {
     func updateObjective(newObjective: LearningObjective, completion: @escaping Completion<LearningObjective>)
     func fetchNewObjectiveMetadata(goalId: String, completion: @escaping Completion<NewObjectiveMetadata>)
     func createObjective(goalId: String, description: String, completion: @escaping Completion<LearningObjective>)
-    func updateObjectiveDescriotion(objective: LearningObjective, newDescription: String, completion: @escaping Completion<LearningObjective>)
+    func updateObjectiveDescription(objective: LearningObjective, newDescription: String, completion: @escaping Completion<LearningObjective>)
     func delete(objective: LearningObjective, completion: @escaping Completion<Void>)
 }
 
@@ -104,7 +104,7 @@ final class LibraryRepository: LibraryRepositoryProtocol {
         }
     }
     
-    func updateObjectiveDescriotion(objective: LearningObjective, newDescription: String, completion: @escaping Completion<LearningObjective>) {
+    func updateObjectiveDescription(objective: LearningObjective, newDescription: String, completion: @escaping Completion<LearningObjective>) {
         remoteService.updateObjectiveDescription(objectiveId: objective.id, newDescription: newDescription) { [weak self] in
             guard let self = self else { return }
             completion(self.mapResult(from: $0))

--- a/LearningJourney/Modules/Features/JLibrary/JLibrary/Sources/Data/Service/LibraryRemoteService.swift
+++ b/LearningJourney/Modules/Features/JLibrary/JLibrary/Sources/Data/Service/LibraryRemoteService.swift
@@ -28,7 +28,7 @@ final class LibraryRemoteService: LibraryRemoteServiceProtocol {
     
     // MARK: - Properties
     
-    private var currentRequest: ApiProtocol?
+    private var requestPool: [ApiProtocol] = []
     
     // MARK: - Initialization
     
@@ -39,32 +39,32 @@ final class LibraryRemoteService: LibraryRemoteServiceProtocol {
     func learningStrands(completion: @escaping Completion ) {
         let endpoint: LibraryEndpoint = .fetchStrand
         let apiRequest = apiFactory.make(endpoint)
-        currentRequest = apiRequest.make(completion: completion)
+        makeRequest(apiRequest, completion: completion)
     }
     
     func learningObjectives(using strandId: String, completion: @escaping Completion) {
         let endpoint: LibraryEndpoint = .fetchObjectives(strandId)
         let apiRequest = apiFactory.make(endpoint)
-        currentRequest = apiRequest.make(completion: completion)
+        makeRequest(apiRequest, completion: completion)
     }
     
     func updateObjective(using objective: LibraryEndpoint.UpdateObjectiveModel, completion: @escaping Completion) {
         let endpoint: LibraryEndpoint = .updateObjective(objective)
         let apiRequest = apiFactory.make(endpoint)
-        currentRequest = apiRequest.make(completion: completion)
+        makeRequest(apiRequest, completion: completion)
     }
     
     func newObjectiveMetadata(goalId: String, completion: @escaping Completion) {
         let endpoint: LibraryEndpoint = .newObjectiveMetadata(goalId)
         let apiRequest = apiFactory.make(endpoint)
-        currentRequest = apiRequest.make(completion: completion)
+        makeRequest(apiRequest, completion: completion)
     }
     
     func createObjective(using newObjectiveModel: LibraryEndpoint.NewObjectiveModel,
                          completion: @escaping Completion) {
         let endpoint: LibraryEndpoint = .createObjective(newObjectiveModel)
         let apiRequest = apiFactory.make(endpoint)
-        currentRequest = apiRequest.make(completion: completion)
+        makeRequest(apiRequest, completion: completion)
     }
     
     func updateObjectiveDescription(objectiveId: String,
@@ -73,13 +73,22 @@ final class LibraryRemoteService: LibraryRemoteServiceProtocol {
     ) {
         let endpoint: LibraryEndpoint = .updateObjectiveDescription(objectiveId, newDescription)
         let apiRequest = apiFactory.make(endpoint)
-        currentRequest = apiRequest.make(completion: completion)
+        makeRequest(apiRequest, completion: completion)
     }
     
     
     func delete(objectiveWithId: String, completion: @escaping Completion) {
         let endpoint: LibraryEndpoint = .deleteObjective(objectiveWithId)
         let apiRequest = apiFactory.make(endpoint)
-        currentRequest = apiRequest.make(completion: completion)
+        makeRequest(apiRequest, completion: completion)
+    }
+    
+    private func makeRequest(_ api: ApiProtocol, completion: @escaping Completion) {
+        guard let currentRequest = api.make(completion: { [weak self] in
+            self?.requestPool.removeAll(where: { $0 === api })
+            completion($0)
+        })
+        else { return }
+        requestPool.append(currentRequest)
     }
 }

--- a/LearningJourney/Modules/Features/JLibrary/JLibrary/Sources/Scenes/CreateObjective/Domain/CreateObjectiveViewModel.swift
+++ b/LearningJourney/Modules/Features/JLibrary/JLibrary/Sources/Scenes/CreateObjective/Domain/CreateObjectiveViewModel.swift
@@ -39,7 +39,6 @@ final class CreateObjectiveViewModel: CreateObjectiveViewModelProtocol {
         }
     }
 
-        
     private let useCases: UseCases
     private let goal: LearningGoal
     private let maxDescriptionCount = 280
@@ -58,7 +57,6 @@ final class CreateObjectiveViewModel: CreateObjectiveViewModelProtocol {
     func handleAppear() {
         fetchMetadata()
     }
-    
 
     func descriptionDidCommit() {
         createObjectiveIfPossible()

--- a/LearningJourney/Modules/Features/JLibrary/JLibrary/Sources/Scenes/ObjectivesList/Domain/ObjectiveCardViewModel.swift
+++ b/LearningJourney/Modules/Features/JLibrary/JLibrary/Sources/Scenes/ObjectivesList/Domain/ObjectiveCardViewModel.swift
@@ -60,7 +60,6 @@ final class ObjectiveCardViewModel: ObjectiveCardViewModelProtocol {
     @Published
     var objectiveDescription: String = ""
     
-    
     var canShowEditingBar: Bool { objective.type == .custom }
     
     private let useCases: UseCases
@@ -116,7 +115,6 @@ final class ObjectiveCardViewModel: ObjectiveCardViewModelProtocol {
         objectWillChange.send()
     }
     
-    
     func didConfirmEditing() {
         canEditDescription = false
         buttonState = .loading
@@ -128,7 +126,7 @@ final class ObjectiveCardViewModel: ObjectiveCardViewModelProtocol {
                 self?.objective = newObjective
                 self?.renderObjective()
             case let .failure(error):
-                self?.renderObjective()// TODO
+                self?.renderObjective() // TODO what to do when an error occurs while updating objective?
             }
         }
     }
@@ -140,9 +138,8 @@ final class ObjectiveCardViewModel: ObjectiveCardViewModelProtocol {
             switch $0 {
             case .success:
                 self?.isDeleted = true
-                break
             case let .failure(error):
-                // TODO
+                // TODO what to do when deletion fails?
                 break
             }
         }

--- a/LearningJourney/Modules/Features/JLibrary/JLibrary/Sources/Scenes/ObjectivesList/Domain/UseCases/DeleteObjectiveUseCase.swift
+++ b/LearningJourney/Modules/Features/JLibrary/JLibrary/Sources/Scenes/ObjectivesList/Domain/UseCases/DeleteObjectiveUseCase.swift
@@ -3,9 +3,9 @@ protocol DeleteObjectiveUseCaseProtocol {
 }
 
 final class DeleteObjectiveUseCase: DeleteObjectiveUseCaseProtocol {
-    private let repository: LibraryRepository
+    private let repository: LibraryRepositoryProtocol
     
-    init(repository: LibraryRepository) {
+    init(repository: LibraryRepositoryProtocol) {
         self.repository = repository
     }
     

--- a/LearningJourney/Modules/Features/JLibrary/JLibrary/Sources/Scenes/ObjectivesList/Domain/UseCases/UpdateObjectiveDescriptionUseCase.swift
+++ b/LearningJourney/Modules/Features/JLibrary/JLibrary/Sources/Scenes/ObjectivesList/Domain/UseCases/UpdateObjectiveDescriptionUseCase.swift
@@ -4,14 +4,14 @@ protocol UpdateObjectiveDescriptionUseCaseProtocol {
 
 final class UpdateObjectiveDescriptionUseCase: UpdateObjectiveDescriptionUseCaseProtocol {
     
-    private let repository: LibraryRepository
+    private let repository: LibraryRepositoryProtocol
     
-    init(repository: LibraryRepository) {
+    init(repository: LibraryRepositoryProtocol) {
         self.repository = repository
     }
     
     func execute(objective: LearningObjective, newDescription: String, completion: @escaping (Result<LearningObjective, Error>) -> Void) {
-        repository.updateObjectiveDescriotion(objective: objective, newDescription: newDescription) {
+        repository.updateObjectiveDescription(objective: objective, newDescription: newDescription) {
             completion($0.mapError { $0 })
         }
     }

--- a/LearningJourney/Modules/Features/JLibrary/JLibraryTests/Sources/Data/LibraryRepositoryTests.swift
+++ b/LearningJourney/Modules/Features/JLibrary/JLibraryTests/Sources/Data/LibraryRepositoryTests.swift
@@ -232,16 +232,34 @@ final class LibraryRepositoryTests: XCTestCase {
 
 final class LibraryRemoteServiceStub: LibraryRemoteServiceProtocol {
     var resultToUse: Result<Data, ApiError> = .failure(.unknown)
+    
+    func learningObjectives(using strandId: String, completion: @escaping Completion) {
+        completion(resultToUse)
+    }
+    
+    func newObjectiveMetadata(goalId: String, completion: @escaping Completion) {
+        completion(resultToUse)
+    }
+    
+    func createObjective(using newObjectiveModel: LibraryEndpoint.NewObjectiveModel, completion: @escaping Completion) {
+        completion(resultToUse)
+    }
+    
+    func updateObjectiveDescription(objectiveId: String, newDescription: String, completion: @escaping Completion) {
+        completion(resultToUse)
+    }
+    
+    func delete(objectiveWithId: String, completion: @escaping Completion) {
+        completion(resultToUse)
+    }
+    
     func learningStrands(completion: @escaping Completion) {
         completion(resultToUse)
     }
-
     
     func learningObjectives(using strandId: Int, completion: @escaping Completion) {
         completion(resultToUse)
     }
-
-
 
     func updateObjective(using objective: LibraryEndpoint.UpdateObjectiveModel, completion: @escaping Completion) {
         completion(resultToUse)

--- a/LearningJourney/Modules/Features/JLibrary/JLibraryTests/Sources/Data/Service/LibraryRemoteServiceTests.swift
+++ b/LearningJourney/Modules/Features/JLibrary/JLibraryTests/Sources/Data/Service/LibraryRemoteServiceTests.swift
@@ -31,7 +31,7 @@ final class LibraryRemoteServiceTests: XCTestCase {
     func test_learningObjectives_itShouldCallApi() {
         // Given
         let expectation = XCTestExpectation()
-        let strandIdDummy = 1
+        let strandIdDummy = UUID().uuidString
         
         // When
         sut.learningObjectives(using: strandIdDummy) { _ in
@@ -48,7 +48,7 @@ final class LibraryRemoteServiceTests: XCTestCase {
         // Given
         let expectation = XCTestExpectation()
         let objectiveDummy: LibraryEndpoint.UpdateObjectiveModel = .init(
-            id: 1,
+            id: UUID().uuidString,
             newStatus: .untutored,
             isBookmarked: false)
         let expectedEndpoint = LibraryEndpoint.updateObjective(objectiveDummy)

--- a/LearningJourney/Modules/Features/JLibrary/JLibraryTests/Sources/Scenes/CreateObjective/CreateObjectiveAssemblerTests.swift
+++ b/LearningJourney/Modules/Features/JLibrary/JLibraryTests/Sources/Scenes/CreateObjective/CreateObjectiveAssemblerTests.swift
@@ -1,0 +1,11 @@
+import XCTest
+import CoreInjector
+import CoreNetworking
+
+@testable import JLibrary
+
+final class CreateObjectiveAssemblerTests: XCTestCase {
+    func test_handleAppear_whenLoading_itShouldReturn() {
+        // TODO
+    }
+}

--- a/LearningJourney/Modules/Features/JLibrary/JLibraryTests/Sources/Scenes/CreateObjective/Domain/CreateObjectiveViewModelTests.swift
+++ b/LearningJourney/Modules/Features/JLibrary/JLibraryTests/Sources/Scenes/CreateObjective/Domain/CreateObjectiveViewModelTests.swift
@@ -1,0 +1,35 @@
+import XCTest
+
+@testable import JLibrary
+
+final class CreateObjectiveViewModelTests: XCTestCase {
+    
+    private let fetchNewObjectiveMetadataUseCaseStub = FetchNewObjectiveMetadataUseCaseStub()
+    private let createNewObjectiveUseCaseStub = CreateNewObjectiveUseCaseStub()
+    private lazy var sut = CreateObjectiveViewModel(
+        useCases: .init(
+            fetchNewObjectiveMetadataUseCase: fetchNewObjectiveMetadataUseCaseStub,
+            createObjectiveUseCase: createNewObjectiveUseCaseStub),
+        goal: .fixture(),
+        isPresented: .constant(true))
+    
+    func test_handleAppear_whenLoading_itShouldReturn() {
+        
+    }
+}
+
+final class FetchNewObjectiveMetadataUseCaseStub: FetchNewObjectiveMetadataUseCaseProtocol {
+    var resultToUse: Result<NewObjectiveMetadata, LibraryRepositoryError> = .failure(.unknown)
+    func execute(goalId: String, then handle: @escaping Completion) {
+        handle(resultToUse)
+    }
+}
+
+final class CreateNewObjectiveUseCaseStub: CreateNewObjectiveUseCaseProtocol {
+    var resultToUse: Result<LearningObjective, LibraryRepositoryError> = .failure(.unknown)
+    func execute(goalId: String, description: String, completion: @escaping Completion) {
+        completion(resultToUse)
+    }
+}
+
+

--- a/LearningJourney/Modules/Features/JLibrary/JLibraryTests/Sources/Scenes/CreateObjective/Domain/UseCases/CreateNewObjectiveUseCaseTests.swift
+++ b/LearningJourney/Modules/Features/JLibrary/JLibraryTests/Sources/Scenes/CreateObjective/Domain/UseCases/CreateNewObjectiveUseCaseTests.swift
@@ -1,0 +1,30 @@
+
+import XCTest
+
+@testable import JLibrary
+
+final class CreateNewObjectiveUseCaseTests: XCTestCase {
+    // MARK: - Properties
+
+    private let libraryRepositorySpy = LibraryRepositorySpy()
+    private lazy var sut = CreateNewObjectiveUseCase(repository: libraryRepositorySpy)
+
+    // MARK: - Unit tests
+
+    func test_execute_itShouldCreateObjectiveInRepository_thenCallCompletion() {
+        // Given
+
+        let completionExpectation = expectation(description: "Completion should be called")
+
+        // When
+
+        sut.execute(goalId: "dummy", description: "dummy") { _ in
+            completionExpectation.fulfill()
+        }
+
+        // Then
+
+        waitForExpectations(timeout: 1, handler: nil)
+        XCTAssertEqual(libraryRepositorySpy.createObjectiveCallCount, 1)
+    }
+}

--- a/LearningJourney/Modules/Features/JLibrary/JLibraryTests/Sources/Scenes/CreateObjective/Domain/UseCases/FetchNewObjectiveMetadataUseCaseTests.swift
+++ b/LearningJourney/Modules/Features/JLibrary/JLibraryTests/Sources/Scenes/CreateObjective/Domain/UseCases/FetchNewObjectiveMetadataUseCaseTests.swift
@@ -1,0 +1,29 @@
+import XCTest
+
+@testable import JLibrary
+
+final class FetchNewObjectiveMetadataUseCaseTests: XCTestCase {
+    // MARK: - Properties
+
+    private let libraryRepositorySpy = LibraryRepositorySpy()
+    private lazy var sut = FetchNewObjectiveMetadataUseCase(repository: libraryRepositorySpy)
+
+    // MARK: - Unit tests
+
+    func test_execute_itShouldFetchMetadata_andComplete() {
+        // Given
+
+        let completionExpectation = expectation(description: "Completion should be called")
+
+        // When
+
+        sut.execute(goalId: "dummy") { _ in
+            completionExpectation.fulfill()
+        }
+
+        // Then
+
+        waitForExpectations(timeout: 1, handler: nil)
+        XCTAssertEqual(libraryRepositorySpy.fetchNewObjectiveMetadataCallCount, 1)
+    }
+}

--- a/LearningJourney/Modules/Features/JLibrary/JLibraryTests/Sources/Scenes/ObjectivesLisst/Domain/ObjectiveCardViewModel.swift
+++ b/LearningJourney/Modules/Features/JLibrary/JLibraryTests/Sources/Scenes/ObjectivesLisst/Domain/ObjectiveCardViewModel.swift
@@ -1,0 +1,227 @@
+import TestingUtils
+import XCTest
+
+@testable import JLibrary
+
+final class ObjectiveCardViewModelTests: XCTestCase {
+    
+    // MARK: - Properties
+    
+    private let toggleLearnUseCaseStub = ToggleLearnUseCaseSpyStub()
+    private let toggleEagerToLearnUseCaseStub = ToggleEagerToLearnUseCaseStub()
+    private let updateObjectiveDescriptionUseCaseStub = UpdateObjectiveDescriptionUseCaseStub()
+    private let deleteObjectiveUseCaseStub = DeleteObjectiveUseCaseStub()
+    
+    // MARK: - Unit tests
+    
+    func test_handleLearnStatusToggled_whenCantEditDescription_itShouldReturn() {
+        // Given
+        
+        let sut = makeSut()
+        sut.buttonState = .empty
+        sut.canEditDescription = true
+        
+        // When
+        
+        sut.handleLearnStatusToggled()
+        
+        // Then
+        XCTAssertEqual(sut.buttonState, .empty)
+        
+    }
+    
+    func test_handleLearnStatusToggled_whenUseCaseSucceeds_itShouldUpdateObjective() {
+        // Given
+        
+        let sut = makeSut()
+        let expectedDescription = UUID().uuidString
+        sut.objectiveDescription = "not expected"
+        toggleLearnUseCaseStub.resultToUse = .success(.fixture(description: expectedDescription))
+        
+        // When
+        
+        sut.handleLearnStatusToggled()
+        
+        // Then
+        
+        XCTAssertEqual(sut.objectiveDescription, expectedDescription)
+    }
+    
+    func test_handleLearnStatusToggled_whenUseCaseFails_itShouldRenderOldObjective() {
+        // Given
+        let expectedDescription = UUID().uuidString
+        let sut = makeSut(using: .fixture(description: expectedDescription))
+        
+        toggleLearnUseCaseStub.resultToUse = .failure(.unknown)
+        
+        // When
+        
+        sut.handleLearnStatusToggled()
+        
+        // Then
+        
+        XCTAssertEqual(sut.objectiveDescription, expectedDescription)
+    }
+    
+    func test_handleWantToLearnToggled_whenCantEditDescription_itShouldReturn() {
+        // Given
+        
+        let sut = makeSut()
+        sut.buttonState = .empty
+        sut.canEditDescription = true
+        
+        // When
+        
+        sut.handleWantToLearnToggled()
+        
+        // Then
+        XCTAssertEqual(sut.buttonState, .empty)
+        
+    }
+    
+    func test_handleWantToLearnToggled_whenUseCaseSucceeds_itShouldUpdateObjective() {
+        // Given
+        
+        let sut = makeSut()
+        let expectedDescription = UUID().uuidString
+        sut.objectiveDescription = "not expected"
+        toggleEagerToLearnUseCaseStub.resultToUse = .success(.fixture(description: expectedDescription))
+        
+        // When
+        
+        sut.handleWantToLearnToggled()
+        
+        // Then
+        
+        XCTAssertEqual(sut.objectiveDescription, expectedDescription)
+    }
+    
+    func test_handleWantToLearnToggled_whenUseCaseFails_itShouldRenderOldObjective() {
+        // Given
+        let expectedDescription = UUID().uuidString
+        let sut = makeSut(using: .fixture(description: expectedDescription))
+        
+        toggleEagerToLearnUseCaseStub.resultToUse = .failure(.unknown)
+        
+        // When
+        
+        sut.handleWantToLearnToggled()
+        
+        // Then
+        
+        XCTAssertEqual(sut.objectiveDescription, expectedDescription)
+    }
+    
+    func test_didStartEditing_itShouldAllowDescriptionEditing() {
+        // Given
+        
+        let sut = makeSut()
+        sut.canEditDescription = false
+        
+        // When
+        
+        sut.didStartEditing()
+        
+        // Then
+        
+        XCTAssertTrue(sut.canEditDescription)
+    }
+    
+    func test_didCancelEditing_itShouldDisallowDescriptionEditing() {
+        // Given
+        
+        let sut = makeSut()
+        sut.canEditDescription = true
+        
+        // When
+        
+        sut.didCancelEditing()
+        
+        // Then
+        
+        XCTAssertFalse(sut.canEditDescription)
+    }
+    
+    func test_didConfirmEditing_whenUseCaseSucceeds_itShouldBlockEditing_andUpdateObjectiveWithUseCase() {
+        // Given
+        let expectedDescription = UUID().uuidString
+        let sut = makeSut()
+        sut.canEditDescription = true
+        updateObjectiveDescriptionUseCaseStub.resultToUse = .success(.fixture(description: expectedDescription))
+        
+        // When
+        
+        sut.didConfirmEditing()
+        
+        // Then
+        
+        XCTAssertFalse(sut.canEditDescription)
+        XCTAssertEqual(expectedDescription, sut.objectiveDescription)
+    }
+    
+    func test_didConfirmEditing_whenUseCaseFails_itShouldUpdateObjectiveWithUseCase() {
+        // Given
+        let expectedDescription = UUID().uuidString
+        let sut = makeSut(using: .fixture(description: expectedDescription))
+        sut.canEditDescription = true
+        updateObjectiveDescriptionUseCaseStub.resultToUse = .failure(DummyError.dummy)
+        
+        // When
+        
+        sut.didConfirmEditing()
+        
+        // Then
+        
+        XCTAssertFalse(sut.canEditDescription)
+        XCTAssertEqual(expectedDescription, sut.objectiveDescription)
+    }
+    
+    func test_didConfirmDeletion_whenUseCaseSucceeds_itShouldBlockEditing_andMarkAsDeleted() {
+        // Given
+        let sut = makeSut()
+        sut.canEditDescription = true
+        deleteObjectiveUseCaseStub.resultToUse = .success(())
+        
+        // When
+        
+        sut.didConfirmDeletion()
+        
+        // Then
+        
+        XCTAssertFalse(sut.canEditDescription)
+        XCTAssertTrue(sut.isDeleted)
+    }
+    
+    // MARK: - Helpers
+    
+    private func makeSut(using objective: LearningObjective = .fixture()) -> ObjectiveCardViewModel {
+        ObjectiveCardViewModel(
+           useCases: .init(
+               toggleLearnUseCase: toggleLearnUseCaseStub,
+               toggleEagerToLearnUseCase: toggleEagerToLearnUseCaseStub,
+               updateObjectiveDescriptionUseCase: updateObjectiveDescriptionUseCaseStub,
+               deleteObjectiveUseCase: deleteObjectiveUseCaseStub),
+           objective: objective)
+    }
+}
+
+final class ToggleEagerToLearnUseCaseStub: ToggleEagerToLearnUseCaseProtocol {
+    var resultToUse: Result<LearningObjective, LibraryRepositoryError> = .failure(.unknown)
+    func execute(objective: LearningObjective, then handle: @escaping Completion) {
+        handle(resultToUse)
+    }
+}
+
+final class UpdateObjectiveDescriptionUseCaseStub: UpdateObjectiveDescriptionUseCaseProtocol {
+    var resultToUse: Result<LearningObjective, Error> = .failure(DummyError.dummy)
+    func execute(objective: LearningObjective, newDescription: String, completion: @escaping (Result<LearningObjective, Error>) -> Void) {
+        completion(resultToUse)
+    }
+}
+
+final class DeleteObjectiveUseCaseStub: DeleteObjectiveUseCaseProtocol {
+    var resultToUse: Result<Void, Error> = .failure(DummyError.dummy)
+    func execute(objective: LearningObjective, completion: @escaping (Result<Void, Error>) -> Void) {
+        completion(resultToUse)
+    }
+}

--- a/LearningJourney/Modules/Features/JLibrary/JLibraryTests/Sources/Scenes/ObjectivesLisst/Domain/UseCases/DeleteObjectiveUseCaseTests.swift
+++ b/LearningJourney/Modules/Features/JLibrary/JLibraryTests/Sources/Scenes/ObjectivesLisst/Domain/UseCases/DeleteObjectiveUseCaseTests.swift
@@ -1,0 +1,30 @@
+import XCTest
+
+@testable import JLibrary
+
+final class DeleteObjectiveUseCaseTests: XCTestCase {
+    // MARK: - Properties
+
+    private let libraryRepositorySpy = LibraryRepositorySpy()
+    private lazy var sut = DeleteObjectiveUseCase(repository: libraryRepositorySpy)
+
+    // MARK: - Unit tests
+
+    func test_execute_itShouldFetchObjectives() {
+        // Given
+
+        let completionExpectation = expectation(description: "Completion should be called")
+
+        // When
+
+        sut.execute(objective: .fixture()) { _ in
+            completionExpectation.fulfill()
+        }
+
+        // Then
+
+        waitForExpectations(timeout: 1, handler: nil)
+        XCTAssertEqual(libraryRepositorySpy.deleteCallCount, 1)
+    }
+    
+}

--- a/LearningJourney/Modules/Features/JLibrary/JLibraryTests/Sources/Scenes/ObjectivesLisst/Domain/UseCases/ToggleEagerToLearnUseCaseTests.swift
+++ b/LearningJourney/Modules/Features/JLibrary/JLibraryTests/Sources/Scenes/ObjectivesLisst/Domain/UseCases/ToggleEagerToLearnUseCaseTests.swift
@@ -1,0 +1,28 @@
+import XCTest
+
+@testable import JLibrary
+
+final class ToggleEagerToLearnUseCaseTests: XCTestCase {
+    
+    func test_execute_itShouldToggleEagerToLearn_andCallRepository() {
+        // Given
+        
+        let repository = LibraryRepositorySpy()
+        let sut = ToggleEagerToLearnUseCase(repository: repository)
+        let bookmarkStub = Bool.random()
+        let expectedBookmark = !bookmarkStub
+        let objective: LearningObjective = .fixture(isBookmarked: bookmarkStub)
+        let expectation = expectation(description: "must call callback")
+        
+        // When
+        
+        sut.execute(objective: objective) { _ in
+            expectation.fulfill()
+        }
+        
+        // Then
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertEqual(repository.updateObjectiveCallCount, 1)
+        XCTAssertEqual(expectedBookmark, repository.updateObjectiveNewObjectivePassed?.isBookmarked)
+    }
+}

--- a/LearningJourney/Modules/Features/JLibrary/JLibraryTests/Sources/Scenes/ObjectivesLisst/Domain/UseCases/ToggleLearnUseCaseTests.swift
+++ b/LearningJourney/Modules/Features/JLibrary/JLibraryTests/Sources/Scenes/ObjectivesLisst/Domain/UseCases/ToggleLearnUseCaseTests.swift
@@ -12,7 +12,6 @@ final class ToggleLearnUseCaseTests: XCTestCase {
     func test_execute_itShouldFlipLearnedFlag() {
         // Given
 
-        let flagStub: Bool = .random()
         let expectedFlag = LearningObjectiveStatus.learning
 
         let completionExpectation = expectation(description: "Completion should be called")
@@ -34,6 +33,31 @@ final class ToggleLearnUseCaseTests: XCTestCase {
 // MARK: - Testing doubles
 
 final class LibraryRepositorySpy: LibraryRepositoryProtocol  {
+    private(set) var fetchNewObjectiveMetadataCallCount = 0
+    func fetchNewObjectiveMetadata(goalId: String, completion: @escaping Completion<NewObjectiveMetadata>) {
+        fetchNewObjectiveMetadataCallCount += 1
+        completion(.success(.fixture()))
+        
+    }
+    
+    private(set) var createObjectiveCallCount = 0
+    func createObjective(goalId: String, description: String, completion: @escaping Completion<LearningObjective>) {
+        createObjectiveCallCount += 1
+        completion(.failure(.unauthorized))
+    }
+    
+    private(set) var updateObjectiveDescriotionCallCount = 0
+    func updateObjectiveDescription(objective: LearningObjective, newDescription: String, completion: @escaping Completion<LearningObjective>) {
+        updateObjectiveDescriotionCallCount += 1
+        completion(.success(.fixture()))
+    }
+    
+    private(set) var deleteCallCount = 0
+    func delete(objective: LearningObjective, completion: @escaping Completion<Void>) {
+        deleteCallCount += 1
+        completion(.failure(.unauthorized))
+    }
+    
     private(set) var fetchStrandsCallCount = 0
     func fetchStrands(completion: @escaping Completion<[LearningStrand]>) {
         fetchStrandsCallCount += 1
@@ -52,5 +76,17 @@ final class LibraryRepositorySpy: LibraryRepositoryProtocol  {
         updateObjectiveCallCount += 1
         updateObjectiveNewObjectivePassed = newObjective
         completion(.failure(.unknown))
+    }
+}
+
+extension NewObjectiveMetadata {
+    static func fixture(strandName: String = .init(),
+                        goalName: String = .init(),
+                        code: String = .init()
+    ) -> Self {
+        .init(
+            strandName: strandName,
+            goalName: goalName,
+            code: code)
     }
 }

--- a/LearningJourney/Modules/Features/JLibrary/JLibraryTests/Sources/Scenes/ObjectivesLisst/Domain/UseCases/UpdateObjectiveDescriptionUseCaseTests.swift
+++ b/LearningJourney/Modules/Features/JLibrary/JLibraryTests/Sources/Scenes/ObjectivesLisst/Domain/UseCases/UpdateObjectiveDescriptionUseCaseTests.swift
@@ -1,0 +1,25 @@
+import XCTest
+
+@testable import JLibrary
+
+final class UpdateObjectiveDescriptionUseCaseTests: XCTestCase {
+    
+    func test_execute_itShouldCallRepository() {
+        // Given
+        
+        let repository = LibraryRepositorySpy()
+        let sut = UpdateObjectiveDescriptionUseCase(repository: repository)
+        let expectation = expectation(description: "must call callback")
+        
+        // When
+        
+        sut.execute(objective: .fixture(), newDescription: "dummy") { _ in
+            expectation.fulfill()
+        }
+        
+        // Then
+        
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertEqual(repository.updateObjectiveDescriotionCallCount, 1)
+    }
+}


### PR DESCRIPTION
## Description
 - Fixes a bug where only the last request was rendered on the screen
 - Changes backend URL to use AWS
 - Displays an alert when backend fails to authenticate due to SIWA state
 - Adds tests that were missing before releasing to students

## Why?
 - Improve UX
 - Improve UX
 - Improve UX
 - Secure our code

## How?
 - Adding keeping a reference to a pool of requests instead of a single request
 - Changing string in production config
 - Toggle alert flag when error 400 occurs

## Testing Plan 
Run unit tests
