### PR TITLE
add generated assets and strings files to codecov ignore list

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,2 +1,3 @@
 ignore:
   - "**/Generated/*.swift"
+  - "**/*Tests/**/*.swift"

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,2 @@
+ignore:
+  - "**/Generated/*.swift"


### PR DESCRIPTION
## Description
Resolves #39 

## Why?
#37 introduced generated files that are being accounted for in the code coverage report, which is not intended behavior

## How?
Adds `codecov.yml` file with a list of ignored paths